### PR TITLE
Start using generic types for state values

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -23,9 +23,9 @@ declare global {
 			sensor_reports_error = 0x84,
 		}
 
-		interface State {
+		interface State<T = any> {
 			/** The value of the state. */
-			val: any;
+			val: T;
 
 			/** Direction flag: false for desired value and true for actual value. Default: false. */
 			ack: boolean;
@@ -168,7 +168,7 @@ declare global {
 			common?: Partial<OtherCommon>;
 		}
 		/** Represents the change of a state */
-		interface ChangedStateObject extends StateObject {
+		interface ChangedStateObject<T = any> extends StateObject {
 			common: StateCommon;
 			native: Record<string, any>;
 			id?: string;
@@ -182,11 +182,11 @@ declare global {
 			/** The names of enums this state is assigned to. For example ["Licht","Garten"] */
 			enumNames?: string[];
 			/** new state */
-			state: State;
+			state: State<T>;
 			/** @deprecated Use state instead **/
-			newState: State;
+			newState: State<T>;
 			/** previous state */
-			oldState: State;
+			oldState: State<T>;
 			/** Name of the adapter instance which set the value, e.g. "system.adapter.web.0" */
 			from?: string;
 			/** Unix timestamp. Default: current time */
@@ -200,10 +200,10 @@ declare global {
 		type Object = StateObject | ChannelObject | DeviceObject | OtherObject;
 		type PartialObject = PartialStateObject | PartialChannelObject | PartialDeviceObject | PartialOtherObject;
 
-		type GetStateCallback = (err: string | null, state?: State) => void;
-		type SetStateCallback = (err: string | null, id?: string) => void;
+		type GetStateCallback<T = any> = (err: string | null, state?: State<T>) => void;
+		type SetStateCallback<T = any> = (err: string | null, id?: string) => void;
 
-		type StateChangeHandler = (obj: ChangedStateObject) => void;
+		type StateChangeHandler<T = any> = (obj: ChangedStateObject<T>) => void;
 
 		type SetObjectCallback = (err: string | null, obj: { id: string }) => void;
 		type GetObjectCallback = (err: string | null, obj: iobJS.Object) => void;
@@ -346,17 +346,17 @@ declare global {
 			 * this can be called synchronously and immediately returns the state.
 			 * Otherwise you need to provide a callback.
 			 */
-			getState: (callback?: GetStateCallback) => void | State | AbsentState;
+			getState: <T = any>(callback?: GetStateCallback<T>) => void | State<T> | AbsentState;
 
 			/**
 			 * Sets all queried states to the given value.
 			 */
-			setState: (id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean, callback?: SetStateCallback) => this;
+			setState: <T extends string | number | boolean>(id: string, state: T | State<T> | Partial<State<T>>, ack?: boolean, callback?: SetStateCallback) => this;
 
 			/**
 			 * Subscribes the given callback to changes of the matched states.
 			 */
-			on: (callback: StateChangeHandler) => this;
+			on: <T = any>(callback: StateChangeHandler<T>) => this;
 		}
 
 		/**
@@ -561,18 +561,18 @@ declare global {
 	/**
 	 * Subscribe to changes of the matched states.
 	 */
-	function on(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler): any;
-	function on(
+	function on<T = any>(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler<T>): any;
+	function on<T = any>(
 		astroOrScheduleOrOptions: iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions, 
-		handler: iobJS.StateChangeHandler
+		handler: iobJS.StateChangeHandler<T>
 	): any;
 	/**
 	 * Subscribe to changes of the matched states.
 	 */
-	function subscribe(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler): any;
-	function subscribe(
+	function subscribe<T = any>(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler<T>): any;
+	function subscribe<T = any>(
 		astroOrScheduleOrOptions: iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions, 
-		handler: iobJS.StateChangeHandler
+		handler: iobJS.StateChangeHandler<T>
 	): any;
 
 	/**
@@ -648,8 +648,8 @@ declare global {
 	 * this can be called synchronously and immediately returns the state.
 	 * Otherwise you need to provide a callback.
 	 */
-	function getState(id: string, callback: iobJS.GetStateCallback): void;
-	function getState(id: string): iobJS.State;
+	function getState<T = any>(id: string, callback: iobJS.GetStateCallback<T>): void;
+	function getState<T = any>(id: string): iobJS.State<T>;
 
 	/**
 	 * Checks if the state with the given ID exists


### PR DESCRIPTION
Start using generic types for state values and their respective handler (in a backwards-compatible way).

This makes handling with states type-safe. 

```typescript
subscribe<boolean>(pattern: "some.id", ({state}) => {state.val.subString(0,1)});
```

The above example will **not** compile, since `state.val` is now a boolean.